### PR TITLE
Add logo placeholder to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
 <body>
 
   <header>
+    <img src="logo.png" alt="CodeSmart Pro Logo" class="logo">
     <h1>CodeSmart Pro API</h1>
     <p>Instant access to CPT, ICD-10, RVU data and modifiers via REST API.</p>
   </header>


### PR DESCRIPTION
## Summary
- update the API docs homepage to include a placeholder logo element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688816876a3c832a883fc8667d746580